### PR TITLE
Improve trades command

### DIFF
--- a/helpers/constants.py
+++ b/helpers/constants.py
@@ -1,6 +1,15 @@
+# Datasource
 URL_THE_GRAPH = 'https://api.thegraph.com/subgraphs/name/gnosis/dfusion-staging'
 RETRIES = 3
-SEPARATOR = '----------------------------'
 
+# Model
 BATCH_TIME_SECONDS = 300
 OWL_DECIMALS = 18
+
+# Presentation
+SEPARATOR = '----------------------------'
+
+# Colors
+COLOR_LABEL = 'green'
+COLOR_LABEL_DELETED = 'red'
+COLOR_SEPARATOR = 'blue'

--- a/helpers/trades.py
+++ b/helpers/trades.py
@@ -25,8 +25,7 @@ def toTradeDto(trade):
   if revertEpoch:
     revertDate = datetime.utcfromtimestamp(int(revertEpoch))
   else:
-    # revertDate = None
-    revertDate = datetime.utcfromtimestamp(0)
+    revertDate = None
 
   return {
     "owner_address": trade['owner']['id'],

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -1,6 +1,6 @@
 from .constants import BATCH_TIME_SECONDS
 
-def format_token(token):
+def format_token_long(token):
   symbol = token['symbol']
   address = token['address']
   name = token['name']
@@ -11,6 +11,18 @@ def format_token(token):
   else:
     return address
 
+def format_token_short(token):
+  symbol = token['symbol']
+  address = token['address']
+  name = token['name']
+  label = symbol or name
+
+  if label:
+    return label
+  else:
+    return address
+
+
 def format_integer(number):
   return str(number) # TODO: Format better the numbers
 
@@ -18,7 +30,10 @@ def format_amount_in_weis(amount, decimals):
   return str(amount / (10 ** decimals)) # TODO: Format better the weis
 
 def format_date(date):
-  return str(date) # TODO: Improve date formatting
+  return '' if date is None else date.strftime("%d/%m/%y")
+
+def format_date_time(date):
+  return '' if date is None else date.strftime("%d/%m/%y %H:%M:%S")
 
 def toDateFromEpoch(epoch):
   return epoch # TODO: Date from epoch

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -17,10 +17,7 @@ def format_token_short(token):
   name = token['name']
   label = symbol or name
 
-  if label:
-    return label
-  else:
-    return address
+  return label if label else address
 
 
 def format_integer(number):


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2352112/76547207-198c1a80-648d-11ea-9b17-4adc540f0244.png)


1. Improves the colors: Uses constants now

2. Retrieves the trade date and reverted trade dates

3. Adds formatting for dates and datetimes. 

4. Adds units for the volumes. i.e. `0.07146464132812033 WETH`

5. The presentation of the order now is divided in different blocks. First the trade date, then id of the trade, then token and volumes, and lastly the transaction

6. Styles the deleted orders using different colors and highlighting the delete date:
![image](https://user-images.githubusercontent.com/2352112/76547016-c7e39000-648c-11ea-8a98-61e3e27645e9.png)


Close #10 