### PR TITLE
Xdai/Rinkeby support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,20 @@ pip install -r requirements.txt
 ./gnop trades --trader 0x7b2e78d4dfaaba045a167a70da285e30e8fca196
 ```
 
-# Debug - Verbose
+## Different Networks
+
+The cli supports mainnet (default), rinkeby and xdai. To specify a network you need to:
+
+```bash
+export NETWORK=xdai
+./gnop trades --count 5 --skip 0
+
+# Or
+export NETWORK=rinkeby
+./gnop trades --count 5 --skip 0
+```
+
+## Debug - Verbose
 
 Verbose mode prints information that is useful for debugging, including the GraphQL query and the url for the endpoint and subgraph:
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,19 +1,43 @@
 from decimal import Decimal
+from enum import Enum
 import os
 
+class Network(Enum):
+  XDAI = 'xdai'
+  RINKEBY = 'rinkeby'
+  MAINNET = 'mainnet'
+
+  @classmethod
+  def from_env(cls):
+    if 'NETWORK' not in os.environ:
+      return Network.MAINNET
+    
+    if os.environ['NETWORK'] == "xdai":
+      return Network.XDAI
+    if os.environ['NETWORK'] == "rinkeby":
+      return Network.RINKEBY
+    if os.environ['NETWORK'] == "mainnet":
+      return Network.MAINNET
+    
+    raise RuntimeError("Unknown env value for Network: " + os.environ['NETWORK'])
+    
+
 # Datasource
-if 'NETWORK' in os.environ and os.environ['NETWORK'] == "xdai":
+network = Network.from_env()
+if network is Network.XDAI:
   URL_API_THE_GRAPH = 'https://api.thegraph.com/subgraphs/name/gnosis/protocol-xdai'
   URL_UI_THE_GRAPH = 'https://thegraph.com/explorer/subgraph/gnosis/protocol-xdai'
   TX_EXPLORER_BASE_URL = 'https://blockscout.com/poa/xdai'
-elif 'NETWORK' in os.environ and os.environ['NETWORK'] == "rinkeby":
+elif network is Network.RINKEBY:
   URL_API_THE_GRAPH = 'https://api.thegraph.com/subgraphs/name/gnosis/protocol-rinkeby'
   URL_UI_THE_GRAPH = 'https://thegraph.com/explorer/subgraph/gnosis/protocol-rinkeby'
   TX_EXPLORER_BASE_URL = 'https://rinkeby.etherscan.io'
-else:
+elif network is Network.MAINNET:
   URL_API_THE_GRAPH = 'https://api.thegraph.com/subgraphs/name/gnosis/protocol'
   URL_UI_THE_GRAPH = 'https://thegraph.com/explorer/subgraph/gnosis/protocol'
   TX_EXPLORER_BASE_URL = 'https://etherscan.io'
+else:
+  raise RuntimeError("Unknown Network")
 
 RETRIES = 3
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -12,11 +12,11 @@ class Network(Enum):
     if 'NETWORK' not in os.environ:
       return Network.MAINNET
     
-    if os.environ['NETWORK'] == "xdai":
+    if os.environ['NETWORK'].casefold() == "xdai":
       return Network.XDAI
-    if os.environ['NETWORK'] == "rinkeby":
+    if os.environ['NETWORK'].casefold() == "rinkeby":
       return Network.RINKEBY
-    if os.environ['NETWORK'] == "mainnet":
+    if os.environ['NETWORK'].casefold() == "mainnet":
       return Network.MAINNET
     
     raise RuntimeError("Unknown env value for Network: " + os.environ['NETWORK'])

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,10 +1,21 @@
 from decimal import Decimal
+import os
 
 # Datasource
-URL_API_THE_GRAPH = 'https://api.thegraph.com/subgraphs/name/gnosis/protocol'
-URL_UI_THE_GRAPH = 'https://thegraph.com/explorer/subgraph/gnosis/protocol'
+if 'NETWORK' in os.environ and os.environ['NETWORK'] == "xdai":
+  URL_API_THE_GRAPH = 'https://api.thegraph.com/subgraphs/name/gnosis/protocol-xdai'
+  URL_UI_THE_GRAPH = 'https://thegraph.com/explorer/subgraph/gnosis/protocol-xdai'
+  TX_EXPLORER_BASE_URL = 'https://blockscout.com/poa/xdai'
+elif 'NETWORK' in os.environ and os.environ['NETWORK'] == "rinkeby":
+  URL_API_THE_GRAPH = 'https://api.thegraph.com/subgraphs/name/gnosis/protocol-rinkeby'
+  URL_UI_THE_GRAPH = 'https://thegraph.com/explorer/subgraph/gnosis/protocol-rinkeby'
+  TX_EXPLORER_BASE_URL = 'https://rinkeby.etherscan.io'
+else:
+  URL_API_THE_GRAPH = 'https://api.thegraph.com/subgraphs/name/gnosis/protocol'
+  URL_UI_THE_GRAPH = 'https://thegraph.com/explorer/subgraph/gnosis/protocol'
+  TX_EXPLORER_BASE_URL = 'https://etherscan.io'
+
 RETRIES = 3
-ETHERSCAN_BASE_URL = 'https://etherscan.io'
 
 # Model
 BATCH_TIME_SECONDS = 300

--- a/src/utils/misc.py
+++ b/src/utils/misc.py
@@ -5,7 +5,7 @@ import csv
 import os
 import sys
 
-from constants import (BATCH_TIME_SECONDS, ETHERSCAN_BASE_URL, MAX_AMOUNT,
+from constants import (BATCH_TIME_SECONDS, TX_EXPLORER_BASE_URL, MAX_AMOUNT,
                        MAX_EPOCH, CSV_DELIMITER, CSV_QUOTE)
 
 
@@ -43,7 +43,7 @@ def calculate_price(numerator, denominator, decimals_numerator, decimals_denomin
 
 
 def to_etherscan_link(hash):
-  return ETHERSCAN_BASE_URL + '/tx/' + hash
+  return TX_EXPLORER_BASE_URL + '/tx/' + hash
 
 
 def get_csv_writer() -> csv.writer:


### PR DESCRIPTION
As title. Was as easy as updating a few base URLs. Decided to make it an env variable rather than a command line argument, as we likely will use the same value for subsequent queries, thus it seemed to make sense to allow setting it globally for a session.


### Test Plan

```
./gnop trades --count 5 --skip 0
```

Works on default, xdai, rinkeby & when mainnet explicitly set.